### PR TITLE
github-actions: use with instead of env

### DIFF
--- a/.github/workflows/publish_post.yaml
+++ b/.github/workflows/publish_post.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        env:
+        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./output


### PR DESCRIPTION
## Types of changes
* github-actions

## Description
Use `with` instead of `env` to load variables

https://github.com/peaceiris/actions-gh-pages/issues/123

