### PR TITLE
post update: fix migration announcement url typo

### DIFF
--- a/content/posts/2023-01-09-migration-annoucement.md
+++ b/content/posts/2023-01-09-migration-annoucement.md
@@ -5,7 +5,7 @@ Category: announcement
 Tags: zh-tw, en
 Slug: migration-announcement
 Authors: Wei Lee
-Summary: PyCon Taiwan 的部落格正式由 [Blogger](https://pycontw.blogspot.com/) 搬到 [GitHub](https://conf.python.tw/) / [https://conf.python.tw](htttps://conf.python.tw) 上囉！
+Summary: PyCon Taiwan 的部落格正式由 [Blogger](https://pycontw.blogspot.com/) 搬到 [GitHub](https://conf.python.tw/) / [https://conf.python.tw](https://conf.python.tw) 上囉！
 
 <!--more-->
 


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
* post update


## Description
<!--Describe what the change is**-->
url should be `https://conf.python.tw` instead of `htttps://conf.python.tw` for #19.

