### PR TITLE
fix typo: correct the picture url

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -7,13 +7,11 @@
         "requires": {
             "python_version": "3.10"
         },
-        "sources": [
-            {
-                "name": "pypi",
-                "url": "https://pypi.org/simple",
-                "verify_ssl": true
-            }
-        ]
+        "sources": [{
+            "name": "pypi",
+            "url": "https://pypi.org/simple",
+            "verify_ssl": true
+        }]
     },
     "default": {
         "beautifulsoup4": {

--- a/content/posts/2023-03-05-gather-town-building.md
+++ b/content/posts/2023-03-05-gather-town-building.md
@@ -5,7 +5,7 @@ Category: online-conference
 Tags: en
 Slug: gather-town-building
 Authors: Winnie, Fish, Ray, Shirley, Vivian, Pochun, TN-Lee, Yoyo, Angus, Allen
-Summary: ![PyCon APAC 2022 Monopoly](images/2023-03-05-gather-town-building/26.jpg) Last year (2022), PyCon Taiwan hosted PyCon APAC for the third time. Due to global epidemic situation, we chose holding PyCon APAC 2022 remotely via Gather.Town. It’s the second time we used Gather.Town to build the conference. We found that Gather.Town kept updating the interface and features, and created lots of friendly example maps for newcomers. In this article, we would introduce the events of PyCon APAC 2022 in the following.
+Summary: ![PyCon APAC 2022 Monopoly](images/2023-03-05-gather-town-building/26-Monopoly.jpg) Last year (2022), PyCon Taiwan hosted PyCon APAC for the third time. Due to global epidemic situation, we chose holding PyCon APAC 2022 remotely via Gather.Town. It’s the second time we used Gather.Town to build the conference. We found that Gather.Town kept updating the interface and features, and created lots of friendly example maps for newcomers. In this article, we would introduce the events of PyCon APAC 2022 in the following.
 
 [TOC]
 


### PR DESCRIPTION
## Types of changes
* fix typo

## Description
Correct the picture url in this post.
Before:
<img width="890" alt="截圖 2023-03-28 下午10 57 17" src="https://user-images.githubusercontent.com/15531846/228279866-39a65ae2-24e1-4ea6-8438-4b663be22777.png">

After:
<img width="799" alt="截圖 2023-03-28 下午10 57 32" src="https://user-images.githubusercontent.com/15531846/228279928-8fa116e7-4d32-4e38-9b2c-cc1e5e38e932.png">
