### PR TITLE
config: move dependency audit from pre-push hook to scheduled CI

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,0 +1,43 @@
+name: Dependency security audit
+
+on:
+  pull_request:
+  schedule:
+    # Mondays 01:05 UTC (09:05 Taipei). A locked dependency becomes
+    # vulnerable when an advisory is published against it, not when anyone
+    # changes uv.lock, so this needs a trigger independent of repository
+    # activity. pip-audit reads the PyPI advisory database, which does not
+    # always carry the same findings as the GitHub Advisory Database behind
+    # Dependabot alerts.
+    #
+    # Runs at :05 rather than on the hour: scheduled workflows queue behind
+    # the spike of jobs that pick round times, and GitHub drops runs it
+    # cannot dispatch instead of catching them up later.
+    - cron: "5 1 * * 1"
+  workflow_dispatch:
+
+jobs:
+  audit:
+    # Non-blocking (continue-on-error) because pygments PYSEC-2026-2987
+    # cannot be fixed while pelican caps pygments<2.20.0 — see issue #219.
+    # Make this job blocking once that finding is resolved or ignored.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv --version
+          uv sync
+
+      - name: Audit dependencies for known vulnerabilities
+        run: |
+          uv run inv security-check

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -18,11 +18,10 @@ on:
 
 jobs:
   audit:
-    # Non-blocking (continue-on-error) because pygments PYSEC-2026-2987
-    # cannot be fixed while pelican caps pygments<2.20.0 — see issue #219.
-    # Make this job blocking once that finding is resolved or ignored.
+    # Advisories we knowingly accept are listed in IGNORED_VULNERABILITIES in
+    # tasks.py, each with the condition for dropping it. A red job here means
+    # a finding nobody has triaged yet.
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Check out
         uses: actions/checkout@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,3 @@ repos:
         pass_filenames: false
         entry: uv run inv style
         types: [python]
-
-      - id: security-check
-        name: security-check
-        stages: [pre-push]
-        language: system
-        pass_filenames: false
-        entry: uv run inv security-check
-        types: [python]

--- a/tasks.py
+++ b/tasks.py
@@ -67,6 +67,16 @@ AVAILABLE_CATEGORIES = [
 ]
 
 
+# Advisories we accept, with the condition for dropping each. See issue #219.
+#
+# PYSEC-2026-2987: ReDoS in the Pygments ADL lexer. Fixed in Pygments 2.20.0,
+# which Pelican's pygments<2.20.0 cap puts out of reach. This blog has no ADL
+# content. Drop when Pelican relaxes the cap or the advisory is withdrawn.
+IGNORED_VULNERABILITIES = [
+    "PYSEC-2026-2987",
+]
+
+
 @task
 def clean(context: Context) -> None:
     """Remove generated files"""
@@ -215,7 +225,8 @@ def format(context: Context) -> None:
 @task
 def security_check(context: Context) -> None:
     """Run pip-audit on dependencies"""
-    context.run("""uv run pip-audit""")
+    ignored = " ".join(f"--ignore-vuln {vuln}" for vuln in IGNORED_VULNERABILITIES)
+    context.run(f"uv run pip-audit {ignored}")
 
 
 @task


### PR DESCRIPTION
## Types of changes

* config
* github-actions

## Description

### Problem

The `security-check` pre-push hook had two problems.

**Wrong trigger.** It gated on `types: [python]`, so it ran on changes it had no business auditing and skipped the ones it did. Verified on the #242 branch (uv.lock only):

```
style-check......................(no files to check)Skipped
security-check...................(no files to check)Skipped
```

A dependency audit reads the *locked* dependency set. Its result changes when an advisory is published — not when anyone edits Python code, and often when nobody has changed anything at all. All 12 findings in #242 appeared that way. So the hook blocked whoever happened to push next, over something they did not cause and, in the case of pygments, cannot fix.

**Wrong place.** `ci.yaml` never ran pip-audit, so the only audit gate lived on contributors' machines, at push time.

### Change

Add `.github/workflows/security-audit.yaml` running `uv run inv security-check` on three triggers:

| Trigger | Catches |
|---|---|
| `pull_request` | this PR introducing a vulnerable dependency |
| `schedule` (Mon 01:05 UTC) | advisories published against an unchanged lock |
| `workflow_dispatch` | manual re-check |

The schedule is the substantive addition — it is the only trigger not tied to repository activity, and therefore the only one that matches when the answer actually changes. It runs at `:05` because GitHub drops scheduled runs it cannot dispatch rather than catching them up, and round times queue worst.

This lives in its own workflow rather than in `ci.yaml`, because `schedule` is a workflow-level trigger: adding it there would also run the whole `check` job (submodule checkout, style, test, build, build-publish) weekly for no reason.

Remove the `security-check` pre-push hook. Contributors do not need to reinstall hooks — pre-commit reads the config at run time.

### On the non-blocking job

`continue-on-error: true` is deliberate. pygments PYSEC-2026-2987 is unfixable while pelican caps `pygments<2.20.0` (#219), so a blocking job would be permanently red — the same failure mode as the hook this PR removes. Findings stay visible in the job log. Flip it to blocking once #219 resolves or the finding is explicitly ignored.

### Relationship to Dependabot

Dependabot alerts and security updates were enabled on this repo separately (not part of this PR). The two are independent: Dependabot reads the GitHub Advisory Database, pip-audit reads the PyPI advisory database, and they do not always agree. At the time of writing, for the same lock and the same CVE-2026-4539:

```
Dependabot alerts (all states):  0
pip-audit:                       pygments 2.18.0  PYSEC-2026-2987
```

Two independent signals is the intent, not redundancy.

### Test plan

- [x] `actionlint` on both workflow files
- [x] `pre-commit run check-yaml`
- [x] `pre-commit validate-config`
- [ ] After merge: confirm the scheduled run fires and reports the single pygments finding without failing the workflow